### PR TITLE
Use express handler definition as path

### DIFF
--- a/lib/express.js
+++ b/lib/express.js
@@ -4,7 +4,11 @@ function middleware(request, response, done) {
   var start = process.hrtime();
 
   response.on('finish', function() {
-    metrics.observe(request.method, request.path, response.statusCode, start);
+    var path = request.path
+    if (typeof request.route !== 'undefined'){
+      path = "handler:" + request.route.path
+    }
+    metrics.observe(request.method, path, response.statusCode, start);
   });
 
   return done();

--- a/lib/labels.js
+++ b/lib/labels.js
@@ -4,6 +4,11 @@ function parse(path) {
     cardinality: 'many'
   }
 
+  if (path.startsWith('handler:')){
+    ret.path = path.replace('handler:','')
+    return ret
+  }
+
   if (path[path.length - 1] != '/') {
     if (!path.includes('.')) {
       ret.path = path.substr(0, path.lastIndexOf('/') + 1);


### PR DESCRIPTION
Test currently broken. Need to work out how to fix them if you want the change.

This lets us get the handler name as the path, avoiding some high
cardinalilty metrics being generated. The prefix is used to prevent
the label generation from modifying the result. This was the best
approach I could think of at the time.