### PR TITLE
Run metrics on a separate port

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
-# Epimetheus 
+# Epimetheus
 [![CircleCI](https://img.shields.io/circleci/project/roylines/node-epimetheus.svg)]()
 [![Coveralls](https://img.shields.io/coveralls/roylines/node-epimetheus.svg)]()
 [![David](https://img.shields.io/david/roylines/node-epimetheus.svg)]()
 
 [![NPM](https://nodei.co/npm/epimetheus.png)](https://nodei.co/npm/epimetheus/)
 
-Middleware to automatically instrument node applications for consumption by a [Prometheus](https://prometheus.io/) server. 
+Middleware to automatically instrument node applications for consumption by a [Prometheus](https://prometheus.io/) server.
 
-Prometheus is an open source monitoring solution that obtains metrics from servers by querying against the /metrics endpoint upon them. 
- 
+Prometheus is an open source monitoring solution that obtains metrics from servers by querying against the /metrics endpoint upon them.
+
 Once instrumented, Epimetheus automatically serves [response duration](#duration), [event loop lag](#lag) and [memory](#memory) metrics on the /metrics endpoint ready to be consumed by Prometheus.
 
 Epimetheus will instrument websites and webservices that use [http](#http), [express](#express), [hapi](#hapi) and [restify](#restify).
 
 # Instrumentation
-Epimetheus automatically measures a number of metrics once instrumented. 
+Epimetheus automatically measures a number of metrics once instrumented.
 There are 3 categories of instrumentation measured: [response duration](#duration), [event loop lag](#lag) and [memory](#memory). See below for details on each.
 The following metrics are instrumented via the /metrics endpoint:
 
@@ -51,11 +51,15 @@ There are three metrics that are measuring the memory usage of the node process,
 Epimetheus has only one method, instrument, and it has the following signature:
 ## instrument(server, options)
 
-The first argument represents the server of the middleware. 
+The first argument represents the server of the middleware.
 
 The second argument is optional, and allows some configuration of epimetheus
 
 - `url` - the url on which to serve metrics. Defaults to `/metrics`.
+- `adminPort` - run metrics on another port.
+
+Supplying the `adminPort` option will start an internal server which will run on
+the specified port and only respond to metrics requests.
 
 See the following examples of use with [http](#http), [express](#express), [hapi](#hapi) and [restify](#restify).
 
@@ -74,7 +78,7 @@ const server = http.createServer((req, res) => {
 epimetheus.instrument(server);
 
 server.listen(8003, '127.0.0.1', () => {
-  console.log('http listening on 8003'); 
+  console.log('http listening on 8003');
 });
 
 ```
@@ -85,7 +89,7 @@ const epimetheus = require('epimetheus');
 
 const app = express();
 epimetheus.instrument(app);
-    
+
 app.get('/', (req, res) => {
   res.send();
 });
@@ -105,9 +109,9 @@ const server = new Hapi.Server();
 server.connection({
   port: 3000
 });
-    
+
 epimetheus.instrument(this.server);
-    
+
 server.route({
   method: 'GET',
   path: '/',
@@ -115,7 +119,7 @@ server.route({
     resp();
   }
 });
-   
+
 server.start(() => {
   console.log('hapi server listening on port 3000');
 });
@@ -141,7 +145,7 @@ server.listen(3000, () => {
 ```
 
 # Try It Out
-The docker-compose.yml file in the examples directory will create a prometheus server and an example each of an [http](#http), [express](#express), [hapi](#hapi) and [restify](#restify) server. 
+The docker-compose.yml file in the examples directory will create a prometheus server and an example each of an [http](#http), [express](#express), [hapi](#hapi) and [restify](#restify) server.
 
 Assuming you have installed [docker](https://docs.docker.com) and [docker-compose](https://docs.docker.com/compose/install/), you can try it out by doing the following:
 
@@ -157,5 +161,5 @@ You can then view the prometheus server on [http://127.0.0.1:9090](http://127.0.
 ![Epimetheus](http://www.greekmythology.com/images/mythology/epimetheus_28.jpg)
 
 Epimetheus was one of the Titans and the brother of Prometheus
-His name is derived from the Greek word meaning 'afterthought', 
-which is the antonym of his brother's name, Prometheus, meaning 'forethought'. 
+His name is derived from the Greek word meaning 'afterthought',
+which is the antonym of his brother's name, Prometheus, meaning 'forethought'.

--- a/index.js
+++ b/index.js
@@ -13,13 +13,13 @@ function instrument(app, options) {
   memoryUsage.instrument();
 
   if (hapi.instrumentable(app)) {
-    hapi.instrument(app, options);
+    return hapi.instrument(app, options);
   } else if (express.instrumentable(app)) {
-    express.instrument(app, options);
+    return express.instrument(app, options);
   } else if (restify.instrumentable(app)) {
-    restify.instrument(app, options);
+    return restify.instrument(app, options);
   } else if (http.instrumentable(app)) {
-    http.instrument(app, options);
+    return http.instrument(app, options);
   }
 }
 

--- a/lib/express.js
+++ b/lib/express.js
@@ -1,4 +1,6 @@
+const defaults = require('./defaults');
 const metrics = require('./metrics');
+const internalServer = require('./internal-server');
 
 function middleware(request, response, done) {
   var start = process.hrtime();
@@ -12,10 +14,14 @@ function middleware(request, response, done) {
 
 function instrument(server, options) {
   server.use(middleware);
-  server.get(options.url, (req, res) => {
-    res.header("content-type", "text/plain");
-    return res.send(metrics.summary());
-  });
+  if (options.adminPort) {
+    return internalServer(defaults(options), metrics);
+  } else {
+    server.get(options.url, (req, res) => {
+      res.header("content-type", "text/plain");
+      return res.send(metrics.summary());
+    });
+  }
 }
 
 function instrumentable(server) {

--- a/lib/http.js
+++ b/lib/http.js
@@ -1,5 +1,6 @@
 const defaults = require('./defaults');
 const metrics = require('./metrics');
+const internalServer = require('./internal-server');
 
 function sendMetrics(request, response) {
   response.writeHead(200, {
@@ -18,13 +19,21 @@ function observeMetrics(request, response) {
 }
 
 function instrument(server, options) {
+  var metricsServer;
+
+  if (options.adminPort) {
+    metricsServer = internalServer(options, metrics);
+  }
+
   server.on('request', (request, response) => {
-    if (request.url === options.url) {
+    if (request.url === options.url && !options.adminPort) {
       sendMetrics(request, response);
     } else {
       observeMetrics(request, response);
     }
   });
+
+  return metricsServer;
 }
 
 function instrumentable(server) {

--- a/lib/internal-server.js
+++ b/lib/internal-server.js
@@ -1,0 +1,18 @@
+const http = require('http');
+
+module.exports = function (options, metrics) {
+  var internalServer = http.createServer((req, res) => {
+    var url = options.url || '/metrics';
+    res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+    if (req.url === url) {
+      res.statusCode = 200;
+      res.end(metrics.summary());
+    } else {
+      res.statusCode = 400;
+      res.end('Not supported');
+    }
+  });
+  internalServer.listen(options.adminPort, '127.0.0.1', () => { });
+
+  return internalServer;
+}

--- a/lib/restify.js
+++ b/lib/restify.js
@@ -1,4 +1,5 @@
 const metrics = require('./metrics');
+const internalServer = require('./internal-server');
 
 function middleware(request, response, done) {
   var start = process.hrtime();
@@ -12,11 +13,17 @@ function middleware(request, response, done) {
 
 function instrument(server, options) {
   server.use(middleware);
-  server.get(options.url, (req, res) => {
-    res.setHeader('Content-Type', 'text/plain');
-    res.charSet('utf-8');
-    return res.send(metrics.summary());
-  });
+
+  if (options.adminPort) {
+    return internalServer(options, metrics);
+  } else {
+    server.get(options.url, (req, res) => {
+      res.setHeader('Content-Type', 'text/plain');
+      res.charSet('utf-8');
+      return res.send(metrics.summary());
+    });
+  }
+
 }
 
 function instrumentable(server) {

--- a/test/assert-expectations.js
+++ b/test/assert-expectations.js
@@ -1,15 +1,20 @@
 const request = require('request');
 const should = require('chai').should();
 
+function port(options) {
+  var opts = options || {};
+  return opts.adminPort || 3000;
+}
+
 module.exports = function(options) {
-    
+
   it('should return 200 for /', (done) => {
     request('http://localhost:3000/', (e, r, b) => {
       r.statusCode.should.equal(200);
       return done(e);
     });
   });
-  
+
   it('should return 200 for /resource/id', (done) => {
     request('http://localhost:3000/resource/101', (e, r, b) => {
       r.statusCode.should.equal(200);
@@ -17,8 +22,8 @@ module.exports = function(options) {
     });
   });
 
-  it('should return 200 for ' + options.url, (done) => {
-    request('http://localhost:3000' + options.url, (e, r, b) => {
+  it('should return 200 for :' + port(options) + options.url, (done) => {
+    request('http://localhost:' + port(options) + options.url, (e, r, b) => {
       r.statusCode.should.equal(200);
       should.exist(r.headers['content-type']);
       r.headers['content-type'].should.equal('text/plain; charset=utf-8');

--- a/test/express.js
+++ b/test/express.js
@@ -4,10 +4,11 @@ const epithemeus = require('../index');
 const assertExpectations = require('./assert-expectations');
 
 function setup(options) {
+  var metricsServer;
   return describe('express ' + options.url, () => {
     before((done) => {
       const app = express();
-      epithemeus.instrument(app, options);
+      metricsServer = epithemeus.instrument(app, options);
       app.get('/', (req, res) => {
         res.send();
       });
@@ -18,6 +19,9 @@ function setup(options) {
     });
 
     after((done) => {
+      if (metricsServer) {
+        metricsServer.close();
+      }
       return this.server.close(done)
     });
 
@@ -28,4 +32,11 @@ function setup(options) {
 setup(defaults());
 setup({
   url: '/xxx'
+});
+setup(defaults({
+  adminPort: 3001
+}));
+setup({
+  url: '/admin-metrics',
+  adminPort: 3001
 });

--- a/test/http.js
+++ b/test/http.js
@@ -4,6 +4,8 @@ const epithemeus = require('../index');
 const assertExpectations = require('./assert-expectations');
 
 function setup(options) {
+  var metricsServer;
+
   return describe('native ' + options.url, () => {
     before((done) => {
       this.server = http.createServer((req, res) => {
@@ -13,12 +15,15 @@ function setup(options) {
         }
       });
 
-      epithemeus.instrument(this.server, options);
+      metricsServer = epithemeus.instrument(this.server, options);
 
       return this.server.listen(3000, '127.0.0.1', done);
     });
 
     after((done) => {
+      if (metricsServer) {
+        metricsServer.close();
+      }
       return this.server.close(done)
     });
 
@@ -29,4 +34,11 @@ function setup(options) {
 setup(defaults());
 setup({
   url: '/xxx'
+});
+setup(defaults({
+  adminPort: 3001
+}));
+setup({
+  url: '/admin-metrics',
+  adminPort: 3001
 });

--- a/test/restify.js
+++ b/test/restify.js
@@ -31,3 +31,7 @@ setup(defaults());
 setup({
   url: '/xxx'
 });
+setup({
+  url: '/admin-metrics',
+  port: 3001
+});


### PR DESCRIPTION
This makes it possible to run the metrics client on another port than the service
itself. If an `adminPort` option is specified, the instrumenting will
create an internal server which responds to requests on the port and the
metrics endpoint (user specified or the default `/metrics`).
