### PR TITLE
Use route path instead of url in metric labels

### DIFF
--- a/lib/express.js
+++ b/lib/express.js
@@ -4,7 +4,7 @@ function middleware(request, response, done) {
   var start = process.hrtime();
 
   response.on('finish', function() {
-    metrics.observe(request.method, request.path, response.statusCode, start);
+    metrics.observe(request.method, request.route.path, response.statusCode, start);
   });
 
   return done();

--- a/lib/hapi.js
+++ b/lib/hapi.js
@@ -20,7 +20,7 @@ function plugin(options) {
       });
 
       server.on('response', (response) => {
-        metrics.observe(response.method, response.path, response.response.statusCode, response.epimetheus.start);
+        metrics.observe(response.method, response.route.path, response.response.statusCode, response.epimetheus.start);
       });
 
       return done();

--- a/lib/labels.js
+++ b/lib/labels.js
@@ -2,14 +2,11 @@ function parse(path) {
   var ret = {
     path: path,
     cardinality: 'many'
-  }
+  };
 
   if (path[path.length - 1] != '/') {
-    if (!path.includes('.')) {
-      ret.path = path.substr(0, path.lastIndexOf('/') + 1);
-    }
     ret.cardinality = 'one';
-  };
+  }
 
   return ret;
 }

--- a/lib/restify.js
+++ b/lib/restify.js
@@ -4,7 +4,7 @@ function middleware(request, response, done) {
   var start = process.hrtime();
 
   response.on('finish', function() {
-    metrics.observe(request.method, request.path(), response.statusCode, start);
+    metrics.observe(request.method, request.route.path, response.statusCode, start);
   });
 
   return done();

--- a/test/assert-expectations.js
+++ b/test/assert-expectations.js
@@ -23,7 +23,7 @@ module.exports = function(options) {
       should.exist(r.headers['content-type']);
       r.headers['content-type'].should.equal('text/plain; charset=utf-8');
       b.should.have.string('# HELP ');
-      b.should.have.string('"/resource/"');
+      b.should.have.string('"' + options.routePath + '"');
       b.should.have.string('cardinality="one"');
       b.should.have.string('cardinality="many"');
       b.should.have.string('status="200"');

--- a/test/express.js
+++ b/test/express.js
@@ -4,6 +4,8 @@ const epithemeus = require('../index');
 const assertExpectations = require('./assert-expectations');
 
 function setup(options) {
+  options.routePath = '/resource/:id';
+
   return describe('express ' + options.url, () => {
     before((done) => {
       const app = express();
@@ -11,7 +13,7 @@ function setup(options) {
       app.get('/', (req, res) => {
         res.send();
       });
-      app.get('/resource/:id', (req, res) => {
+      app.get(options.routePath, (req, res) => {
         res.send();
       });
       this.server = app.listen(3000, done);

--- a/test/hapi.js
+++ b/test/hapi.js
@@ -4,6 +4,8 @@ const epithemeus = require('../index');
 const assertExpectations = require('./assert-expectations');
 
 function setup(options) {
+  options.routePath = '/resource/{id}';
+
   return describe('hapi ' + options.url, () => {
     before((done) => {
       this.server = new Hapi.Server();
@@ -20,7 +22,7 @@ function setup(options) {
       });
       this.server.route({
         method: 'GET',
-        path: '/resource/101',
+        path: options.routePath,
         handler: (req, resp) => {
           resp();
         }

--- a/test/http.js
+++ b/test/http.js
@@ -4,6 +4,8 @@ const epithemeus = require('../index');
 const assertExpectations = require('./assert-expectations');
 
 function setup(options) {
+  options.routePath = '/resource/101';
+
   return describe('native ' + options.url, () => {
     before((done) => {
       this.server = http.createServer((req, res) => {

--- a/test/labels.js
+++ b/test/labels.js
@@ -6,17 +6,17 @@ describe('labels', () => {
     labels.parse('/users/').path.should.equal('/users/');
     labels.parse('/users/').cardinality.should.equal('many');
   });
-  it('should parse /users/freddie', () => {
-    labels.parse('/users/freddie').path.should.equal('/users/');
-    labels.parse('/users/freddie').cardinality.should.equal('one');
+  it('should parse /users/:freddie', () => {
+    labels.parse('/users/:freddie').path.should.equal('/users/:freddie');
+    labels.parse('/users/:freddie').cardinality.should.equal('one');
   });
   it('should parse /staff/users/', () => {
     labels.parse('/staff/users/').path.should.equal('/staff/users/');
     labels.parse('/staff/users/').cardinality.should.equal('many');
   });
-  it('should parse /staff/users/freddie', () => {
-    labels.parse('/staff/users/freddie').path.should.equal('/staff/users/');
-    labels.parse('/staff/users/freddie').cardinality.should.equal('one');
+  it('should parse /staff/users/:freddie', () => {
+    labels.parse('/staff/users/:freddie').path.should.equal('/staff/users/:freddie');
+    labels.parse('/staff/users/:freddie').cardinality.should.equal('one');
   });
   it('should parse /static/page.css', () => {
     labels.parse('/static/page.css').path.should.equal('/static/page.css');

--- a/test/restify.js
+++ b/test/restify.js
@@ -4,6 +4,8 @@ const epithemeus = require('../index');
 const assertExpectations = require('./assert-expectations');
 
 function setup(options) {
+  options.routePath = '/resource/:id';
+
   describe('restify ' + options.url, () => {
     before((done) => {
       this.server = restify.createServer();
@@ -12,7 +14,7 @@ function setup(options) {
         res.send();
         done();
       });
-      this.server.get('/resource/:id', (req, res, done) => {
+      this.server.get(options.routePath, (req, res, done) => {
         res.send();
         done();
       });


### PR DESCRIPTION
The previous method to deal with the Url doesn't handle very good routes like `/foo/123/bar` where `foo` and `bar` are resource names and `123` is a changing id.

We change to use the routes as defined in the routers with placeholders, ex : '/foo/{id}/bar'
