### PR TITLE
remove res.charSet fixes #34

### DIFF
--- a/lib/express.js
+++ b/lib/express.js
@@ -13,7 +13,7 @@ function middleware (request, response, done) {
 function instrument (server, options) {
   server.use(middleware)
   server.get(options.url, (req, res) => {
-    res.header('content-type', 'text/plain')
+    res.header('content-type', 'text/plain; charset=utf-8')
     return res.send(metrics.summary())
   })
 }

--- a/lib/restify.js
+++ b/lib/restify.js
@@ -16,8 +16,7 @@ function middleware (request, response, done) {
 function instrument (server, options) {
   server.use(middleware)
   server.get(options.url, (req, res) => {
-    res.setHeader('Content-Type', 'text/plain')
-    res.charSet('utf-8')
+    res.setHeader('Content-Type', 'text/plain; charset=utf-8')
     return res.send(metrics.summary())
   })
 }

--- a/lib/restify.js
+++ b/lib/restify.js
@@ -17,7 +17,13 @@ function instrument (server, options) {
   server.use(middleware)
   server.get(options.url, (req, res) => {
     res.setHeader('Content-Type', 'text/plain; charset=utf-8')
-    return res.send(metrics.summary())
+    /**
+     * Using send uses the native Node handlers rather than the restify one
+     * changing send to end di the job
+     * 
+     * see https://stackoverflow.com/questions/28680755/setting-content-type-header-with-restify-results-in-application-octet-stream
+     */
+    return res.end(metrics.summary())
   })
 }
 


### PR DESCRIPTION
super simple fix to support express4 breaking change of removing `res.charSet` fixes #34 