### PR TITLE
Expose prom-client

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,17 @@ Assuming you have installed [docker](https://docs.docker.com) and [docker-compos
 
 You can then view the prometheus server on [http://127.0.0.1:9090](http://127.0.0.1:9090)
 
+## Register your own metrics
+
+Epimetheus exposes the prometheus client it's using through the `prometheus`
+property. You can use this to register your own custom metrics:
+
+```
+const client = require('epimetheus').prometheus;
+
+new client.Counter({name: 'test_counter', help: 'A simple counter'});
+```
+
 # Etymology
 
 ![Epimetheus](http://www.greekmythology.com/images/mythology/epimetheus_28.jpg)

--- a/index.js
+++ b/index.js
@@ -24,5 +24,6 @@ function instrument (app, options) {
 }
 
 module.exports = {
-  instrument: instrument
+  instrument: instrument,
+  prometheus: require('prom-client')
 }

--- a/test/assert-expectations.js
+++ b/test/assert-expectations.js
@@ -1,10 +1,22 @@
 const request = require('request')
 const should = require('chai').should()
+const client = require('../').prometheus;
+
+function getTestCount() {
+  return client.register.getSingleMetric('test_counter').get().values[0].value;
+}
 
 module.exports = function (options) {
+  let previousCount = null;
+  
+  beforeEach(() => {
+    previousCount = client.register.getSingleMetric('test_counter').get().values[0].value;
+  });
+
   it('should return 200 for /', (done) => {
     request('http://localhost:3000/', (e, r, b) => {
       r.statusCode.should.equal(200)
+      getTestCount().should.be.above(previousCount);
       return done(e)
     })
   })
@@ -12,6 +24,7 @@ module.exports = function (options) {
   it('should return 200 for /resource/id', (done) => {
     request('http://localhost:3000/resource/101', (e, r, b) => {
       r.statusCode.should.equal(200)
+      getTestCount().should.be.above(previousCount);
       return done(e)
     })
   })

--- a/test/custom-metrics.js
+++ b/test/custom-metrics.js
@@ -1,0 +1,5 @@
+const client = require('../').prometheus;
+
+// This registers a counter which we will increment whenever a server 
+// receives a request.
+exports.count = new client.Counter({name: 'test_counter', help: 'Number of test runs'});

--- a/test/express.js
+++ b/test/express.js
@@ -9,9 +9,11 @@ function setup (options) {
       const app = express()
       epithemeus.instrument(app, options)
       app.get('/', (req, res) => {
+        require('./custom-metrics').count.inc();
         res.send()
       })
       app.get('/resource/:id', (req, res) => {
+        require('./custom-metrics').count.inc();
         res.send()
       })
       this.server = app.listen(3000, done)

--- a/test/globals.js
+++ b/test/globals.js
@@ -1,0 +1,8 @@
+const should = require('chai').should();
+
+describe('globals', () => {
+    it('should expose the internal prometheus client', () => {
+        const Epimetheus = require('../');
+        Epimetheus.prometheus.should.not.be.undefined;
+    });
+});

--- a/test/hapi.js
+++ b/test/hapi.js
@@ -17,6 +17,7 @@ function setup (options) {
         method: 'GET',
         path: '/',
         handler: (req, resp) => {
+          require('./custom-metrics').count.inc();
           resp()
         }
       })
@@ -24,6 +25,7 @@ function setup (options) {
         method: 'GET',
         path: '/resource/101',
         handler: (req, resp) => {
+          require('./custom-metrics').count.inc();
           resp()
         }
       })

--- a/test/http.js
+++ b/test/http.js
@@ -7,6 +7,7 @@ function setup (options) {
   return describe('native ' + options.url, () => {
     before((done) => {
       this.server = http.createServer((req, res) => {
+        require('./custom-metrics').count.inc();
         if (req.url !== options.url) {
           res.statusCode = 200
           res.end()

--- a/test/restify.js
+++ b/test/restify.js
@@ -9,10 +9,12 @@ function setup (options) {
       this.server = restify.createServer()
       epithemeus.instrument(this.server, options)
       this.server.get('/', (req, res, done) => {
+        require('./custom-metrics').count.inc();
         res.send()
         done()
       })
       this.server.get('/resource/:id', (req, res, done) => {
+        require('./custom-metrics').count.inc();
         res.send()
         done()
       })


### PR DESCRIPTION
This will allow users to register custom metrics and expose them through the same registry.