### PR TITLE
Hapi example: use `server` instead of `this.server`

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ server.connection({
   port: 3000
 });
 
-epimetheus.instrument(this.server);
+epimetheus.instrument(server);
 
 server.route({
   method: 'GET',


### PR DESCRIPTION
In Readme for the Hapi example `this.server` is not correct in this case. With `server` the expression works as expected.