### PR TITLE
Fixed example prometheus config

### DIFF
--- a/examples/prometheus/prometheus.yml
+++ b/examples/prometheus/prometheus.yml
@@ -4,14 +4,14 @@ global:
 
 scrape_configs:
   - job_name: 'express'
-    target_groups:
+    static_configs:
       - targets: ['express:8000']
   - job_name: 'restify'
-    target_groups:
+    static_configs:
       - targets: ['restify:8001']
   - job_name: 'hapi'
-    target_groups:
+    static_configs:
       - targets: ['hapi:8002']
   - job_name: 'http'
-    target_groups:
+    static_configs:
       - targets: ['http:8003']


### PR DESCRIPTION
Fixed an issue with the prometheus/prometheus.yml config that was not allowing the example to run. The config `target_groups` needed to be changed to `static_configs`. Props to @Elexy who reported the issue and mentioned how to fix it in the following issue https://github.com/roylines/node-epimetheus/issues/41 


<img width="1329" alt="screen shot 2018-04-20 at 1 50 30 pm" src="https://user-images.githubusercontent.com/2416999/39066448-1a6b3e4c-44a3-11e8-9773-cd7c713a541f.png">
