### PR TITLE
Add request.baseUrl to express path

### DIFF
--- a/lib/express.js
+++ b/lib/express.js
@@ -4,7 +4,7 @@ function middleware (request, response, done) {
   var start = process.hrtime()
 
   response.on('finish', function () {
-    metrics.observe(request.method, request.path, response.statusCode, start)
+    metrics.observe(request.method, request.baseUrl + request.path, response.statusCode, start)
   })
 
   return done()


### PR DESCRIPTION
When using a hierarchical router structure in Express, request.baseUrl must be added to the path. Otherwise, you only get the path in the last router. Note, this modified code also works for plain non-hierarchical structures. request.baseUrl is then an empty string.